### PR TITLE
[11.0][stock_location_address] 

### DIFF
--- a/stock_location_address/__init__.py
+++ b/stock_location_address/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import models

--- a/stock_location_address/__manifest__.py
+++ b/stock_location_address/__manifest__.py
@@ -12,8 +12,6 @@
     'depends': [
         'stock',
     ],
-    'demo': [
-    ],
     'data': [
         'views/stock_location_views.xml',
     ],

--- a/stock_location_address/models/__init__.py
+++ b/stock_location_address/models/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import stock_location

--- a/stock_location_address/models/stock_location.py
+++ b/stock_location_address/models/stock_location.py
@@ -17,10 +17,18 @@ class StockLocation(models.Model):
         compute='_compute_real_address_id',
     )
 
+    def _get_parent_address(self):
+        if self.location_id and self.location_id.address_id:
+            return self.location_id.address_id
+        elif self.location_id:
+            return self.location_id._get_parent_address()
+        else:
+            return self.env['res.partner']
+
     @api.depends('address_id', 'location_id')
     def _compute_real_address_id(self):
         for record in self:
             if record.address_id:
                 record.real_address_id = record.address_id
             elif record.location_id:
-                record.real_address_id = record.location_id.real_address_id
+                record.real_address_id = record._get_parent_address()

--- a/stock_location_address/tests/__init__.py
+++ b/stock_location_address/tests/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import test_location_address

--- a/stock_location_address_purchase/__init__.py
+++ b/stock_location_address_purchase/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import models

--- a/stock_location_address_purchase/models/__init__.py
+++ b/stock_location_address_purchase/models/__init__.py
@@ -1,3 +1,1 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import purchase

--- a/stock_location_address_purchase/tests/__init__.py
+++ b/stock_location_address_purchase/tests/__init__.py
@@ -1,2 +1,1 @@
-
 from . import test_purchase_address


### PR DESCRIPTION
- code style fixes
- fixes computation of real_address_id

With various levels of locations the real_address_id was not being computed correctly on children. In demo data, for example, in WH/Stock/Shelf 1 was not showing the real address that was maintained in WH/Stock.